### PR TITLE
Recognize datetime datatype

### DIFF
--- a/foxyjunk.py
+++ b/foxyjunk.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 
 def interpret(data):
     """Interprets uncompressed SQLite
@@ -48,6 +49,11 @@ def interpret(data):
             offset += ItemCount
             if ItemCount % 8 != 0:
                 offset += 8 - (ItemCount % 8)
+        elif datatype == 0xffff0005: # datetime
+            offset += 8
+            segment = data[offset:offset+8]
+            timestamp = struct.unpack('<d', bytes(segment))[0] / 1000
+            curr = datetime.fromtimestamp(timestamp).isoformat()
         elif datatype == 0xffff0007: # array
             ItemCount = int.from_bytes(segment[0:4], "little")
             curr = { "FindKey": True, "Object": [] }


### PR DESCRIPTION
The timestamp is then converted to isoformat.

I don't know if you are interested in improving this. Anyway, thank you very much for your work on this, I would not have done this myself.
I'm using the feedbro extension to manage my RSS feeds and I wanted for quite some time to backup the articles in an readable way and go through them in a python script.
I finally took the time to find why I had weird results. Datetime were not recognized.
I chose here to convert them to isoformat to easily write the result to a JSON file as datetime objects are not JSON serializable (not straightforwardly at least).